### PR TITLE
Support values from other tests in result.tree

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -30,13 +30,23 @@ Represents the mapped ML-tree.
 ### Bipartition format
 
 `-f`, `--out-format` specifies the format of bipartition.
-Format string has some special commands.
+Some keywords of format were replaced by specified values from tests below.
+You should be careful that these keywords are recognized as "case-sensitive".
 
 - `{src}`: Replaced by the evaluation value in source tree file (BP, UFBP, SH-aLRT etc.)
-- `{bin}`: Replaced by whether the bipartition is supported or not. 
-  `1` represents the bipartition is supported by AU-test (All NNI trees are rejected).
-  `0` represents the bipartition is not supported (Any NNI trees are not rejected)
-- `{p}`: Replaced by the max *p*-value of NNI trees
+- `{bin}`, `{au-bin}`: Replaced by whether the 0/1 value representing the bipartition was supported by AU test or not.
+  - `1` represents the bipartition was supported (all alternative trees were rejected).
+  - `0` represents the bipartition was not supported (any alternative trees were not rejected).
+- `{p}`, `{au-p}`: Replaced by the max *p*-value by AU test of alternative trees.
+- `{sh-bin}`: 0/1 value representing the bipartition was supported by SH test.
+- `{sh-p}`: Max *p*-value by SH test of alternative trees.
+- `{kh-bin}`: 0/1 value representing the bipartition was supported by KH test.
+- `{kh-p}`: Max *p*-value by KH test of alternative trees.
+- `{wsh-bin}`: 0/1 value representing the bipartition was supported by weighted SH test.
+- `{wsh-p}`: Max *p*-value by weighted SH test of alternative trees.
+- `{wkh-bin}`: 0/1 value representing the bipartition was supported by weighted KH test.
+- `{wkh-p}`: Max *p*-value by weighted KH test of alternative trees.
+- `{dlnL}`: Minimum of observed log-likelihood difference between the ML tree and alternative trees.
 
 **Examples**
 

--- a/src/autoeb/__init__.py
+++ b/src/autoeb/__init__.py
@@ -3,5 +3,6 @@ from .consel_manager import ConselManager
 from .configuration import Configuration
 from .iqtree_manager import IqtreeManager
 from .operation_manager import OperationManager
+from .output_formatter import OutputFormatter
 from .statistics_entry import StatisticsEntry
 from .value_range import ValueRange

--- a/src/autoeb/consts.py
+++ b/src/autoeb/consts.py
@@ -1,6 +1,3 @@
-OUT_FORMAT_SRC: str = "{src}"
-OUT_FORMAT_BIN: str = "{bin}"
-OUT_FORMAT_P: str = "{p}"
 RESULT_OK: str = "1"
 RESULT_NG: str = "0"
 INFILE_SEQ: str = "seq.fasta"

--- a/src/autoeb/cui/command_arguments.py
+++ b/src/autoeb/cui/command_arguments.py
@@ -26,7 +26,7 @@ class CommandArguments:
         """
         result: str = self.__namespace.seq
         if not os.path.isfile(result):
-            raise ArgumentError(None, f"sequence file '{result}' does not exists")
+            raise ArgumentError(None, f"Sequence file '{result}' does not exists")
         return os.path.abspath(result)
 
     @property
@@ -35,7 +35,7 @@ class CommandArguments:
         """
         result: str = self.__namespace.tree
         if not os.path.isfile(result):
-            raise ArgumentError(None, f"tree file '{result}' does not exists")
+            raise ArgumentError(None, f"Tree file '{result}' does not exists")
         return os.path.abspath(result)
 
     @property
@@ -50,7 +50,7 @@ class CommandArguments:
         """
         result: int = self.__namespace.bootstrap
         if result < 1000:
-            raise ArgumentError(None, "value must be greater or equal to 1000")
+            raise ArgumentError(None, "Value of '-b' option must be greater or equal to 1000")
         return result
 
     @property
@@ -59,7 +59,7 @@ class CommandArguments:
         """
         result: int = self.__namespace.seed
         if result < -1:
-            raise ArgumentError(None, "value must be greater or equal to -1")
+            raise ArgumentError(None, "Value of '--seed' option must be greater or equal to -1")
         return result
 
     @property
@@ -83,7 +83,7 @@ class CommandArguments:
         """
         result: float = self.__namespace.sig_level
         if result < 0 or 1 < result:
-            raise ArgumentError(None, "value must be within the range 0 to 1")
+            raise ArgumentError(None, "Value of '--sig-level' option must be within the range 0 to 1")
         return result
 
     @property
@@ -99,7 +99,7 @@ class CommandArguments:
         """
         result: int = self.__namespace.thread
         if result < 1:
-            raise ArgumentError(None, "value must be greater or equal to 1")
+            raise ArgumentError(None, "Value of '-T' option must be greater or equal to 1")
         return result
 
     @property
@@ -117,7 +117,7 @@ class CommandArguments:
         """
         result: str | None = self.__namespace.iqtree_param
         if not (result is None) and not os.path.isfile(result):
-            raise ArgumentError(None, f"text file '{result}' does not exist")
+            raise ArgumentError(None, f"Text file '{result}' does not exist")
         return result
 
     @property

--- a/src/autoeb/cui/command_arguments.py
+++ b/src/autoeb/cui/command_arguments.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentError, ArgumentParser, Namespace
 import os
 
-from ..consts import OUT_FORMAT_BIN, OUT_FORMAT_SRC
 from ..nnigen.io import TreeIOHandler, treetype
 from ..value_range import ValueRange
 
@@ -166,7 +165,7 @@ class CommandArguments:
         parser.add_argument("-b", "--bootstrap", default=10_0000, type=int, help="replicates of RELL bootstrap (>=1000, default=100,000)", metavar="INT")
         parser.add_argument("--seed", default=-1, type=int, help="seed of random value (>= -1). if larger than 0, specified value is used for seed (default=-1)", metavar="INT")
         parser.add_argument("-o", "--out", type=str, required=True, help="destination folder", metavar="DIR")
-        parser.add_argument("-f", "--out-format", default=f"{OUT_FORMAT_SRC}/{OUT_FORMAT_BIN}", type=str, help=f"format of branch name (default='{OUT_FORMAT_SRC}/{OUT_FORMAT_BIN}')", metavar="STR")
+        parser.add_argument("-f", "--out-format", default='{src}/{bin}', type=str, help="format of branch name (default='{src}/{bin}')", metavar="STR")
         parser.add_argument("-T", "--thread", default=1, type=int, help="numbmer of threads IQ-TREE uses (default=1)", metavar="INT")
         parser.add_argument("--iqtree-verbose", action="store_true", help="redirect IQ-TREE stdout")
         parser.add_argument("--output-tmp-files", action="store_true", help="output files IQ-TREE and CONSEL generated")

--- a/src/autoeb/cui/command_arguments.py
+++ b/src/autoeb/cui/command_arguments.py
@@ -2,6 +2,7 @@ from argparse import ArgumentError, ArgumentParser, Namespace
 import os
 
 from ..nnigen.io import TreeIOHandler, treetype
+from ..output_formatter import OutputFormatter
 from ..value_range import ValueRange
 
 
@@ -105,7 +106,10 @@ class CommandArguments:
     def out_format(self) -> str:
         """出力フォーマットを取得します。
         """
-        return self.__namespace.out_format
+        result: str = self.__namespace.out_format
+        if not OutputFormatter.check_format(result):
+            raise ArgumentError(None, "Invalid format by '-f' option was detected")
+        return result
 
     @property
     def iqtree_params(self) -> str | None:

--- a/src/autoeb/main.py
+++ b/src/autoeb/main.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentError
 from sys import stderr
 
 from .cui import CommandArguments
@@ -19,6 +20,11 @@ def main(args: list[str]) -> int:
         return 1
     arguments = CommandArguments(args)
     manager = OperationManager(arguments)
-    manager.execute()
+
+    try:
+        manager.execute()
+    except ArgumentError as e:
+        print(e.message, file=stderr)
+        return 1
 
     return 0

--- a/src/autoeb/operation_manager.py
+++ b/src/autoeb/operation_manager.py
@@ -293,56 +293,6 @@ class OperationManager:
         operation_end = datetime.now()
         print(f"  Operation No. {branch_index} / {branch_count - 1} finished in {(operation_end - operation_start)}", file=self.__logger)
 
-    @staticmethod
-    def __format_output_branch_name(fmt: str, src: str, sig_level: float, catpv: CatpvResult) -> str:
-
-        # Formats of "fmt"
-        #
-        # {src}: Support values in given tree
-        # {bin}, {au-bin}: 0/1 value by AU test
-        # {p}, {au-p}: p-value of the alternative topology greater than the other by AU test
-        # {sh-bin}: 0/1 value by SH test
-        # {sh-p}: p-value of the alternative topology greater than the other by SH test
-        # {kh-bin}: 0/1 value by KH test
-        # {kh-p}: p-value of the alternative topology greater than the other by KH test
-        # {wsh-bin}: 0/1 value by weighted SH test
-        # {wsh-p}: p-value of the alternative topology greater than the other by weighted SH test
-        # {wkh-bin}: 0/1 value by weighted KH test
-        # {wkh-p}: p-value of the alternative topology greater than the other by weighted KH test
-        # {dlnL}: Observed log-likelihood difference of the alternative topology less than the other
-
-        max_au_p: float = max(catpv.stat_nni1.au, catpv.stat_nni2.au)
-        au_bin: str = RESULT_OK if sig_level > max_au_p else RESULT_NG
-        max_sh_p: float = max(catpv.stat_nni1.sh, catpv.stat_nni2.sh)
-        sh_bin: str = RESULT_OK if sig_level > max_sh_p else RESULT_NG
-        max_kh_p: float = max(catpv.stat_nni1.kh, catpv.stat_nni2.kh)
-        kh_bin: str = RESULT_OK if sig_level > max_kh_p else RESULT_NG
-        max_wsh_p: float = max(catpv.stat_nni1.wsh, catpv.stat_nni2.wsh)
-        wsh_bin: str = RESULT_OK if sig_level > max_wsh_p else RESULT_NG
-        max_wkh_p: float = max(catpv.stat_nni1.wkh, catpv.stat_nni2.wkh)
-        wkh_bin: str = RESULT_OK if sig_level > max_wkh_p else RESULT_NG
-        min_obs: float = max(catpv.stat_nni1.obs, catpv.stat_nni2.obs)
-
-        replace_dict: dict[str, object] = {
-            'src': src,
-            'bin': au_bin,
-            'p': max_au_p,
-            'au-bin': au_bin,
-            'au-p': max_au_p,
-            'sh-bin': sh_bin,
-            'sh-p': max_sh_p,
-            'kh-bin': kh_bin,
-            'kh-p': max_kh_p,
-            'wsh-bin': wsh_bin,
-            'wsh-p': max_wsh_p,
-            'wkh-bin': wkh_bin,
-            'wkh-p': max_wkh_p,
-            'dlnL': min_obs,
-        }
-
-        result: str = fmt.format(**replace_dict)
-        return result
-
     def __iterate_all_tmpfiles(self, index: int) -> Generator[str, None, None]:
         """インデックスに対応する中間ファイルを全て列挙します。
 

--- a/src/autoeb/operation_manager.py
+++ b/src/autoeb/operation_manager.py
@@ -302,10 +302,52 @@ class OperationManager:
 
         Returns:フォーマットされた枝名
         """
+
+        # Formats of "fmt"
+        #
+        # {src}: Support values in given tree
+        # {bin}, {au-bin}: 0/1 value by AU test
+        # {p}, {au-p}: p-value of the alternative topology greater than the other by AU test
+        # {sh-bin}: 0/1 value by SH test
+        # {sh-p}: p-value of the alternative topology greater than the other by SH test
+        # {kh-bin}: 0/1 value by KH test
+        # {kh-p}: p-value of the alternative topology greater than the other by KH test
+        # {wsh-bin}: 0/1 value by weighted SH test
+        # {wsh-p}: p-value of the alternative topology greater than the other by weighted SH test
+        # {wkh-bin}: 0/1 value by weighted KH test
+        # {wkh-p}: p-value of the alternative topology greater than the other by weighted KH test
+        # {dlnL}: Observed log-likelihood difference of the alternative topology less than the other
+
         max_au_p: float = max(catpv.stat_nni1.au, catpv.stat_nni2.au)
         au_bin: str = RESULT_OK if sig_level > max_au_p else RESULT_NG
+        max_sh_p: float = max(catpv.stat_nni1.sh, catpv.stat_nni2.sh)
+        sh_bin: str = RESULT_OK if sig_level > max_sh_p else RESULT_NG
+        max_kh_p: float = max(catpv.stat_nni1.kh, catpv.stat_nni2.kh)
+        kh_bin: str = RESULT_OK if sig_level > max_kh_p else RESULT_NG
+        max_wsh_p: float = max(catpv.stat_nni1.wsh, catpv.stat_nni2.wsh)
+        wsh_bin: str = RESULT_OK if sig_level > max_wsh_p else RESULT_NG
+        max_wkh_p: float = max(catpv.stat_nni1.wkh, catpv.stat_nni2.wkh)
+        wkh_bin: str = RESULT_OK if sig_level > max_wkh_p else RESULT_NG
+        min_obs: float = max(catpv.stat_nni1.obs, catpv.stat_nni2.obs)
 
-        result: str = fmt.format(src=src, bin=au_bin, p=max_au_p)
+        replace_dict: dict[str, object] = {
+            'src': src,
+            'bin': au_bin,
+            'p': max_au_p,
+            'au-bin': au_bin,
+            'au-p': max_au_p,
+            'sh-bin': sh_bin,
+            'sh-p': max_sh_p,
+            'kh-bin': kh_bin,
+            'kh-p': max_kh_p,
+            'wsh-bin': wsh_bin,
+            'wsh-p': max_wsh_p,
+            'wkh-bin': wkh_bin,
+            'wkh-p': max_wkh_p,
+            'dlnL': min_obs,
+        }
+
+        result: str = fmt.format(**replace_dict)
         return result
 
     def __iterate_all_tmpfiles(self, index: int) -> Generator[str, None, None]:

--- a/src/autoeb/operation_manager.py
+++ b/src/autoeb/operation_manager.py
@@ -17,6 +17,7 @@ from .consts import *
 from .cui import CommandArguments
 from .iqtree_manager import IqtreeManager
 from .nnigen import read_tree, Tree
+from .output_formatter import OutputFormatter
 from .slh_data import SlhData
 from .summary import SummaryInfo
 from .value_range import ValueRange
@@ -61,6 +62,8 @@ class OperationManager:
         if not self.__args.iqtree_params is None:
             iqtree_manager.load_other_params(self.__args.iqtree_params)
         consel_manager = ConselManager(self.__config)
+
+        formatter = OutputFormatter(self.__args.out_format)
 
         if not self.__args.redo and os.path.isfile(SITELH_PATH):
             print(f"Site likelyhood calculation is skipped ('{OUTFILE_SITELH}' already exists)", file=self.__logger)
@@ -144,7 +147,7 @@ class OperationManager:
             # parse CATPV file
             catpv = CatpvResult.load(self.__args.get_out_file_path(f"{bipartition_index}.catpv"))[0]
             # change branch name
-            current.name = self.__format_output_branch_name(self.__args.out_format, current.name, self.__args.sig_level, catpv)
+            current.name = formatter.format(current.name, catpv, self.__args.sig_level)
             nni: list[Tree] = [Tree(nni.find_root()) for nni in current.get_nni()]
             if self.__args.sig_level <= catpv.stat_nni1.au:
                 valid_nni.append((catpv.stat_nni1.au, nni[1]))
@@ -292,16 +295,6 @@ class OperationManager:
 
     @staticmethod
     def __format_output_branch_name(fmt: str, src: str, sig_level: float, catpv: CatpvResult) -> str:
-        """出力ツリーの枝名を取得します。
-
-        Args:
-            fmt (str): 枝名のフォーマット
-            src (str): 元の枝名
-            sig_level (float): 有意水準
-            catpv (CatpvResult): IQTREEファイルの情報
-
-        Returns:フォーマットされた枝名
-        """
 
         # Formats of "fmt"
         #

--- a/src/autoeb/operation_manager.py
+++ b/src/autoeb/operation_manager.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from datetime import datetime
 from distutils.file_util import copy_file
-from genericpath import isfile
 import glob
 from io import TextIOWrapper
 from multiprocessing.pool import ThreadPool
@@ -303,10 +302,10 @@ class OperationManager:
 
         Returns:フォーマットされた枝名
         """
-        max_p: float = max(catpv.stat_nni1.au, catpv.stat_nni2.au)
-        result: str = fmt.replace(OUT_FORMAT_SRC, src)\
-                         .replace(OUT_FORMAT_BIN, RESULT_OK if sig_level > max_p else RESULT_NG)\
-                         .replace(OUT_FORMAT_P, str(max_p))
+        max_au_p: float = max(catpv.stat_nni1.au, catpv.stat_nni2.au)
+        au_bin: str = RESULT_OK if sig_level > max_au_p else RESULT_NG
+
+        result: str = fmt.format(src=src, bin=au_bin, p=max_au_p)
         return result
 
     def __iterate_all_tmpfiles(self, index: int) -> Generator[str, None, None]:

--- a/src/autoeb/output_formatter.py
+++ b/src/autoeb/output_formatter.py
@@ -1,0 +1,104 @@
+import regex
+
+from .consts import RESULT_NG, RESULT_OK
+from .catpv_result import CatpvResult
+
+
+class OutputFormatter:
+    __compatible_keys: set[str] = {
+        'src',
+        'bin',
+        'p',
+        'au-bin',
+        'au-p',
+        'sh-bin',
+        'sh-p',
+        'kh-bin',
+        'kh-p',
+        'wsh-bin',
+        'wsh-p',
+        'wkh-bin',
+        'wkh-p',
+        'dlnL',
+    }
+
+    def __init__(self, format: str) -> None:
+        """OutputFormatterの新しインスタンスを初期化します。
+
+        Args:
+            format (str): サポート値のフォーマット
+        """
+        self.__format: str = format
+
+    @classmethod
+    def check_format(cls, format: str) -> bool:
+        """フォーマット文字列が正常かどうかを検証します。
+
+        Args:
+            format (str): 検証するフォーマット文字列
+
+        Returns:
+            bool: formatが有効の場合はTrue，それ以外でFalse
+        """
+        matches: list[str] = regex.findall(r"{(.*?)}", format)
+        for current_key in matches:
+            if not current_key in cls.__compatible_keys:
+                return False
+        return True
+
+    def format(self, src: str, catpv: CatpvResult, sig_level: float) -> str:
+        """出力ツリーの枝名を取得します。
+
+        Args:
+            src (str): 元の枝名
+            catpv (CatpvResult): CATPVファイルの情報
+            sig_level (float): 有意水準
+
+        Returns:フォーマットされた枝名
+        """
+
+        # Formats of "fmt"
+        #
+        # {src}: Support values in given tree
+        # {bin}, {au-bin}: 0/1 value by AU test
+        # {p}, {au-p}: p-value of the alternative topology greater than the other by AU test
+        # {sh-bin}: 0/1 value by SH test
+        # {sh-p}: p-value of the alternative topology greater than the other by SH test
+        # {kh-bin}: 0/1 value by KH test
+        # {kh-p}: p-value of the alternative topology greater than the other by KH test
+        # {wsh-bin}: 0/1 value by weighted SH test
+        # {wsh-p}: p-value of the alternative topology greater than the other by weighted SH test
+        # {wkh-bin}: 0/1 value by weighted KH test
+        # {wkh-p}: p-value of the alternative topology greater than the other by weighted KH test
+        # {dlnL}: Observed log-likelihood difference of the alternative topology less than the other
+
+        max_au_p: float = max(catpv.stat_nni1.au, catpv.stat_nni2.au)
+        au_bin: str = RESULT_OK if sig_level > max_au_p else RESULT_NG
+        max_sh_p: float = max(catpv.stat_nni1.sh, catpv.stat_nni2.sh)
+        sh_bin: str = RESULT_OK if sig_level > max_sh_p else RESULT_NG
+        max_kh_p: float = max(catpv.stat_nni1.kh, catpv.stat_nni2.kh)
+        kh_bin: str = RESULT_OK if sig_level > max_kh_p else RESULT_NG
+        max_wsh_p: float = max(catpv.stat_nni1.wsh, catpv.stat_nni2.wsh)
+        wsh_bin: str = RESULT_OK if sig_level > max_wsh_p else RESULT_NG
+        max_wkh_p: float = max(catpv.stat_nni1.wkh, catpv.stat_nni2.wkh)
+        wkh_bin: str = RESULT_OK if sig_level > max_wkh_p else RESULT_NG
+        min_obs: float = max(catpv.stat_nni1.obs, catpv.stat_nni2.obs)
+
+        replace_dict: dict[str, object] = {
+            'src': src,
+            'bin': au_bin,
+            'p': max_au_p,
+            'au-bin': au_bin,
+            'au-p': max_au_p,
+            'sh-bin': sh_bin,
+            'sh-p': max_sh_p,
+            'kh-bin': kh_bin,
+            'kh-p': max_kh_p,
+            'wsh-bin': wsh_bin,
+            'wsh-p': max_wsh_p,
+            'wkh-bin': wkh_bin,
+            'wkh-p': max_wkh_p,
+            'dlnL': min_obs,
+        }
+
+        return self.__format.format(**replace_dict)


### PR DESCRIPTION
- `-f` オプションでSH検定などの他の検定の結果や対数尤度差を表示できるように改修
- ドキュメントをそれに合わせて修正
- 他エラーメッセージの出力を修正